### PR TITLE
Fix #24 - Generated byte code uses incorrect table object when indexing the result of a function

### DIFF
--- a/rembulan-compiler/src/main/java/net/sandius/rembulan/compiler/IRTranslatorTransformer.java
+++ b/rembulan-compiler/src/main/java/net/sandius/rembulan/compiler/IRTranslatorTransformer.java
@@ -209,6 +209,11 @@ class IRTranslatorTransformer extends Transformer {
 
 	@Override
 	public LValueExpr transform(IndexExpr e) {
+		Val value = null;
+		if (assigning) {
+			value = popVal();
+		}
+
 		boolean as = assigning;
 		assigning = false;
 
@@ -222,7 +227,6 @@ class IRTranslatorTransformer extends Transformer {
 		insns.atLine(e.line());
 
 		if (assigning) {
-			Val value = popVal();
 			insns.add(new TabSet(obj, key, value));
 		}
 		else {


### PR DESCRIPTION
This PR implements the second solution proposed in #24